### PR TITLE
AutoExit configuration

### DIFF
--- a/src/Cli/AutoExit.php
+++ b/src/Cli/AutoExit.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace WonderNetwork\SlimKernel\Cli;
+
+use DI\Definition\Definition;
+use function DI\value;
+
+final class AutoExit {
+    private bool $value;
+
+    public static function yes(): Definition {
+        return value(new self(true));
+    }
+
+    public static function no(): Definition {
+        return value(new self(false));
+    }
+
+    private function __construct(bool $value) {
+        $this->value = $value;
+    }
+
+    public function value(): bool {
+        return $this->value;
+    }
+}

--- a/src/ServiceFactory/SymfonyConsoleServiceFactory.php
+++ b/src/ServiceFactory/SymfonyConsoleServiceFactory.php
@@ -5,6 +5,7 @@ namespace WonderNetwork\SlimKernel\ServiceFactory;
 
 use DI\Definition\Helper\CreateDefinitionHelper;
 use Symfony\Component\Console;
+use WonderNetwork\SlimKernel\Cli\AutoExit;
 use WonderNetwork\SlimKernel\ServiceFactory;
 use WonderNetwork\SlimKernel\ServicesBuilder;
 use function DI\autowire;
@@ -22,6 +23,7 @@ final class SymfonyConsoleServiceFactory implements ServiceFactory {
 
     public function __invoke(ServicesBuilder $builder): iterable {
         yield from $commands = $builder->autowire()->glob($this->path);
+        yield AutoExit::class => AutoExit::no();
 
         yield Console\Application::class => collection($commands)
             ->keys()
@@ -29,7 +31,7 @@ final class SymfonyConsoleServiceFactory implements ServiceFactory {
                 static fn(CreateDefinitionHelper $def, string $command) => $def->method('add', get($command)),
                 autowire()
                     ->constructor($this->name)
-                    ->method('setAutoExit', false),
+                    ->method('setAutoExit', static fn (AutoExit $autoExit) => $autoExit->value()),
             );
     }
 }

--- a/tests/ServiceFactory/SymfonyConsoleServiceFactoryTest.php
+++ b/tests/ServiceFactory/SymfonyConsoleServiceFactoryTest.php
@@ -22,7 +22,7 @@ class SymfonyConsoleServiceFactoryTest extends TestCase {
         $commands = $actual
             ->keys()
             ->reverse()
-            ->drop(1)
+            ->drop(count(['Application', 'AutoExit']))
             ->reverse()
             ->toArray();
 

--- a/tests/StartupHook/ErrorHandlingHookTest.php
+++ b/tests/StartupHook/ErrorHandlingHookTest.php
@@ -5,13 +5,14 @@ namespace WonderNetwork\SlimKernel\StartupHook;
 
 use Acme\ErrorHandlingSpy;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Slim\App;
 use Slim\Psr7\Factory\ServerRequestFactory;
 use Throwable;
 use WonderNetwork\SlimKernel\KernelBuilder;
 
 class ErrorHandlingHookTest extends TestCase {
-    public function testCustomMiddlewaresTakePrecedence() {
+    public function testCustomMiddlewaresTakePrecedence(): void {
         $container = KernelBuilder::start(__DIR__.'/../Resources/ErrorMiddleware')
             ->glob('app/services/*.php')
             ->onStartup(
@@ -20,7 +21,7 @@ class ErrorHandlingHookTest extends TestCase {
             )
             ->build();
 
-        /** @var App $app */
+        /** @var App<ContainerInterface> $app */
         $app = $container->get(App::class);
         /** @var ErrorHandlingSpy $spy */
         $spy = $container->get(ErrorHandlingSpy::class);

--- a/tests/StartupHook/RoutesStartupHookTest.php
+++ b/tests/StartupHook/RoutesStartupHookTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 namespace WonderNetwork\SlimKernel\StartupHook;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Slim\App;
 use Slim\Psr7\Factory\ServerRequestFactory;
 use WonderNetwork\SlimKernel\KernelBuilder;
 
 class RoutesStartupHookTest extends TestCase {
     public function test(): void {
-        /** @var App $app */
+        /** @var App<ContainerInterface> $app */
         $app = KernelBuilder::start(__DIR__.'/../Resources/App')
             ->glob('app/services/*.php')
             ->onStartup(


### PR DESCRIPTION
Allows to configure if symfony console exits automatically by overriding the `AutoExit::class` service